### PR TITLE
Updated deb dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ po/*.mo
 themes/**/*.png
 themes/**/*.xpm
 arch/PKGBUILD
+.idea/**

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: xfce
 Priority: optional
 Maintainer: Cedric Leporcq <cedl38@gmail.com>
 Build-Depends: debhelper (>= 9), ui-auto, pkg-config, intltool, 
-  libgtk2.0-0 (>= 2.20.0), libxfce4util6 (>= 4.10), libxfconf-0-2 (>= 4.10),
+  libgtk2.0-0 (>= 2.20.0), libxfce4util7 (>= 4.10), libxfconf-0-2 (>= 4.10),
   libxfce4ui-1-dev (>= 4.10), libwnck-dev (>= 2.30),
   xfce4-dev-tools, libglib2.0-dev, libgtk2.0-dev, libx11-dev, libxfce4ui-1-0,
   xfce4-panel-dev, imagemagick, python3


### PR DESCRIPTION
- Updated deb packaging dependency libxfce4util6 -> libxfce4util7
  so sources can be build on Ubuntu 15.10+. This should solve #27
- Added .gitignore for IntellijIDEAs project files.