### PR TITLE
Reverted libxfce4panel-2.0 dependency for 0.4.5 release

### DIFF
--- a/configure.ac.in
+++ b/configure.ac.in
@@ -8,7 +8,7 @@ dnl *** Version information ***
 dnl ***************************
 m4_define([windowck_version_major], [0])
 m4_define([windowck_version_minor], [4])
-m4_define([windowck_version_micro], [4])
+m4_define([windowck_version_micro], [5])
 m4_define([windowck_version_nano],  []) dnl leave this empty to have no nano version
 m4_define([windowck_version_build], [@REVISION@])
 m4_define([windowck_version_tag],   [])
@@ -77,7 +77,7 @@ dnl ***********************************
 XDT_CHECK_PACKAGE([GTK], [gtk+-2.0], [2.20.0])
 XDT_CHECK_PACKAGE([LIBXFCE4UI], [libxfce4ui-1], [4.10.0])
 XDT_CHECK_PACKAGE([LIBXFCE4UTIL], [libxfce4util-1.0], [4.10.0])
-XDT_CHECK_PACKAGE([LIBXFCE4PANEL], [libxfce4panel-2.0], [4.12.0])
+XDT_CHECK_PACKAGE([LIBXFCE4PANEL], [libxfce4panel-1.0], [4.12.0])
 XDT_CHECK_PACKAGE([XFCONF], [libxfconf-0], [4.10.0])
 XDT_CHECK_PACKAGE([LIBWNCK], [libwnck-1.0], [2.30])
 


### PR DESCRIPTION
- Preparations for 0.4.5 release, which is compatible with Ubuntu 17.04, while previous 0.4.4 release is compatible with ubuntu 16.04, 16.10 and maybe 15.04, 15.10.