### PR TITLE
Fix build fail caused by warnings treated as errors

### DIFF
--- a/common/mypixmap.c
+++ b/common/mypixmap.c
@@ -53,37 +53,3 @@ pixbuf_alpha_load (const gchar * dir, const gchar * file)
     }
     return NULL;
 }
-
-
-static GdkPixbuf *
-pixmap_compose (GdkPixbuf *pixbuf, const gchar * dir, const gchar * file)
-{
-    GdkPixbuf *alpha;
-    gint width, height;
-
-    alpha = pixbuf_alpha_load (dir, file);
-
-    if (!alpha)
-    {
-        /* We have no suitable image to layer on top of the XPM, stop here... */
-        return (pixbuf);
-    }
-
-    if (!pixbuf)
-    {
-        /* We have no XPM canvas and found a suitable image, use it... */
-        return (alpha);
-    }
-
-    width  = MIN (gdk_pixbuf_get_width (pixbuf),
-                  gdk_pixbuf_get_width (alpha));
-    height = MIN (gdk_pixbuf_get_height (pixbuf),
-                  gdk_pixbuf_get_height (alpha));
-
-    gdk_pixbuf_composite (alpha, pixbuf, 0, 0, width, height,
-                          0, 0, 1.0, 1.0, GDK_INTERP_NEAREST, 0xFF);
-
-    g_object_unref (alpha);
-
-    return pixbuf;
-}

--- a/common/theme.c
+++ b/common/theme.c
@@ -55,9 +55,7 @@ gchar *test_theme_dir (const gchar *theme, const char *themedir, const gchar *fi
 gchar *
 get_unity_theme_dir (const gchar *theme, const gchar *default_theme)
 {
-    const gchar *file;
     gchar *abs_path;
-    gint i;
 
     if (g_path_is_absolute (theme))
     {

--- a/panel-plugin/buttons/wckbuttons-dialogs.c
+++ b/panel-plugin/buttons/wckbuttons-dialogs.c
@@ -217,7 +217,8 @@ wckbuttons_load_themes (GtkWidget *theme_name_treeview, WBPlugin *wb)
 static gint
 wckbuttons_theme_sort_func (GtkTreeModel *model,
                                GtkTreeIter  *iter1,
-                               GtkTreeIter  *iter2)
+                               GtkTreeIter  *iter2,
+                               void *unused)
 {
   gchar *str1 = NULL;
   gchar *str2 = NULL;
@@ -302,7 +303,7 @@ static GtkWidget * build_properties_area(WBPlugin *wb, const gchar *buffer, gsiz
             {
             list_store = gtk_list_store_new (N_COLUMNS, G_TYPE_STRING, G_TYPE_STRING);
             gtk_tree_sortable_set_sort_func (GTK_TREE_SORTABLE (list_store), COL_THEME_NAME,
-                                             (GtkTreeIterCompareFunc) wckbuttons_theme_sort_func,
+                                             wckbuttons_theme_sort_func,
                                              NULL, NULL);
             gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE (list_store), COL_THEME_NAME, GTK_SORT_ASCENDING);
             gtk_tree_view_set_model (GTK_TREE_VIEW (theme_name_treeview), GTK_TREE_MODEL (list_store));

--- a/panel-plugin/buttons/wckbuttons-theme.c
+++ b/panel-plugin/buttons/wckbuttons-theme.c
@@ -28,52 +28,6 @@
 #define XPM_COLOR_SYMBOL_SIZE 22
 
 
-static gboolean
-set_g_value (const gchar * lvalue, const GValue *rvalue, Settings *rc)
-{
-    gint i;
-
-    TRACE ("entering setValue");
-
-    g_return_val_if_fail (lvalue != NULL, FALSE);
-    g_return_val_if_fail (rvalue != NULL, FALSE);
-
-    for (i = 0; rc[i].option; i++)
-    {
-        if (!g_ascii_strcasecmp (lvalue, rc[i].option))
-        {
-            if (rvalue)
-            {
-                if (rc[i].value)
-                {
-                    g_value_unset (rc[i].value);
-                    g_value_init (rc[i].value, G_VALUE_TYPE(rvalue));
-                }
-                else
-                {
-                    rc[i].value = g_new0(GValue, 1);
-                    g_value_init (rc[i].value, G_VALUE_TYPE(rvalue));
-                }
-
-                g_value_copy (rvalue, rc[i].value);
-                return TRUE;
-            }
-        }
-    }
-    return FALSE;
-}
-
-
-static gboolean
-set_string_value (const gchar * lvalue, const gchar *value, Settings *rc)
-{
-    GValue tmp_val = {0, };
-    g_value_init(&tmp_val, G_TYPE_STRING);
-    g_value_set_static_string(&tmp_val, value);
-    return set_g_value (lvalue, &tmp_val, rc);
-}
-
-
 static void get_unity_pixbuf (const gchar *themedir, WBPlugin *wb) {
     gint i,j;
     gchar imagename[40];

--- a/panel-plugin/title/windowck.c
+++ b/panel-plugin/title/windowck.c
@@ -243,7 +243,7 @@ static WindowckPlugin * windowck_new(XfcePanelPlugin *plugin)
     orientation = xfce_panel_plugin_get_orientation(plugin);
 
     /* not needed for shrink mode */
-    if (!wckp->prefs->size_mode == SHRINK)
+    if (wckp->prefs->size_mode != SHRINK)
         xfce_panel_plugin_set_shrink (plugin, TRUE);
 
     /* create some panel widgets */


### PR DESCRIPTION
I've seen no mention of failing builds, yet when I download the source, run `autogen.sh` and then try to build I get a number of warnings treated as errors. It probably wouldn't hurt to fix those, so here you go.

This removes a number of unused static functions and local variables, changes a callback function signature to avoid a bad cast, and fixes a wrong comparison. I'm pretty sure the comparison (in `panel-plugin/title/windowck.c`) was wrong, but please check if that's really the case.