### PR TITLE
Fix crash on closing last active window.

### DIFF
--- a/panel-plugin/title/windowck-title.c
+++ b/panel-plugin/title/windowck-title.c
@@ -123,6 +123,7 @@ static void on_name_changed (WnckWindow *controlwindow, WindowckPlugin *wckp)
     const gchar *title_text;
 
     if (controlwindow
+	&& wnck_window_get_pid(controlwindow)  // if active window has been closed, pid is 0
         && ((wnck_window_get_window_type (controlwindow) != WNCK_WINDOW_DESKTOP)
             || wckp->prefs->show_on_desktop))
     {


### PR DESCRIPTION
As described in #61, the plugin currently crashes frequently. This can reliably be reproduced by setting the plugin to track active windows, and not show on the desktop. Then closing the last non-minimised window on a workspace will always cause the window title plugin to crash. This commit fixes this by checking whether the controlwindow argument of in on_name_changed refers to a window belonging to an existing process.